### PR TITLE
Wrappers for combined Queue and Topic

### DIFF
--- a/src/main/java/com/github/marschall/jakartajmsadapter/JakartaConnectionFactory.java
+++ b/src/main/java/com/github/marschall/jakartajmsadapter/JakartaConnectionFactory.java
@@ -11,7 +11,7 @@ import jakarta.jms.JMSException;
  * Adapts a {@link javax.jms.ConnectionFactory} to a {@link jakarta.jms.ConnectionFactory}
  */
 public sealed class JakartaConnectionFactory implements ConnectionFactory
-  permits JakartaQueueConnectionFactory, JakartaTopicConnectionFactory {
+  permits JakartaQueueConnectionFactory, JakartaTopicConnectionFactory, JakartaQueueTopicConnectionFactory {
 
   private final javax.jms.ConnectionFactory javaxConnectionFactory;
 

--- a/src/main/java/com/github/marschall/jakartajmsadapter/JakartaDestination.java
+++ b/src/main/java/com/github/marschall/jakartajmsadapter/JakartaDestination.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import jakarta.jms.Destination;
 
 abstract sealed class JakartaDestination implements Destination, Wrapper
-    permits JakartaQueue, JakartaTopic {
+    permits JakartaQueue, JakartaTopic, JakartaQueueTopic {
 
   private final javax.jms.Destination javaxDestination;
 

--- a/src/main/java/com/github/marschall/jakartajmsadapter/JakartaQueueTopic.java
+++ b/src/main/java/com/github/marschall/jakartajmsadapter/JakartaQueueTopic.java
@@ -1,0 +1,45 @@
+package com.github.marschall.jakartajmsadapter;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
+
+/**
+ * Adapts a Java EE destination that implements both {@link javax.jms.Queue} and {@link javax.jms.Topic} to a Jakarta EE destination that
+ * implements both {@link Queue} and {@link Topic}.
+ * <p>
+ * {@code public} for cases where a queue is looked up through JNDI.
+ */
+public final class JakartaQueueTopic extends JakartaDestination implements Queue, Topic {
+
+    private final javax.jms.Queue javaxQueue;
+    private final javax.jms.Topic javaxTopic;
+
+    public JakartaQueueTopic(javax.jms.Destination javaxDestination) {
+        super(javaxDestination);
+        if (!(javaxDestination instanceof javax.jms.Queue javaxQueue && javaxDestination instanceof javax.jms.Topic javaxTopic)) {
+            throw new IllegalArgumentException("does not implement both destinations: " + javaxDestination.getClass());
+        }
+        this.javaxQueue = javaxQueue;
+        this.javaxTopic = javaxTopic;
+    }
+
+    @Override
+    public String getQueueName() throws JMSException {
+        try {
+            return this.javaxQueue.getQueueName();
+        } catch (javax.jms.JMSException e) {
+            throw JMSExceptionUtil.adaptException(e);
+        }
+    }
+
+    @Override
+    public String getTopicName() throws JMSException {
+        try {
+            return this.javaxTopic.getTopicName();
+        } catch (javax.jms.JMSException e) {
+            throw JMSExceptionUtil.adaptException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/github/marschall/jakartajmsadapter/JakartaQueueTopicConnectionFactory.java
+++ b/src/main/java/com/github/marschall/jakartajmsadapter/JakartaQueueTopicConnectionFactory.java
@@ -1,0 +1,72 @@
+package com.github.marschall.jakartajmsadapter;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.QueueConnection;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
+
+/**
+ * Adapts a factory that implements both {@link javax.jms.QueueConnectionFactory} and  {@link javax.jms.TopicConnectionFactory} to a
+ * factory that implements both {@link jakarta.jms.QueueConnectionFactory} and {@link jakarta.jms.TopicConnectionFactory}
+ */
+public final class JakartaQueueTopicConnectionFactory extends JakartaConnectionFactory
+        implements QueueConnectionFactory, TopicConnectionFactory {
+
+    private final javax.jms.QueueConnectionFactory javaxQueueConnectionFactory;
+    private final javax.jms.TopicConnectionFactory javaxTopicConnectionFactory;
+
+    /**
+     * Constructs a new {@link JakartaQueueTopicConnectionFactory}
+     *
+     * @param javaxQueueTopicConnectionFactory the javax connection factory to adapt, not {@code null}
+     * @throws NullPointerException if {@code javaxQueueConnectionFactory} is {@code null}
+     */
+    public JakartaQueueTopicConnectionFactory(javax.jms.ConnectionFactory javaxQueueTopicConnectionFactory) {
+        super(javaxQueueTopicConnectionFactory);
+        if (!(javaxQueueTopicConnectionFactory instanceof javax.jms.QueueConnectionFactory javaxQueueConnectionFactory &&
+                javaxQueueTopicConnectionFactory instanceof javax.jms.TopicConnectionFactory javaxTopicConnectionFactory)) {
+            throw new IllegalArgumentException("does not implement both connection factories: " +
+                    javaxQueueTopicConnectionFactory.getClass());
+        }
+        this.javaxQueueConnectionFactory = javaxQueueConnectionFactory;
+        this.javaxTopicConnectionFactory = javaxTopicConnectionFactory;
+    }
+
+    @Override
+    public QueueConnection createQueueConnection() throws JMSException {
+        try {
+            return new JakartaQueueConnection(this.javaxQueueConnectionFactory.createQueueConnection());
+        } catch (javax.jms.JMSException e) {
+            throw JMSExceptionUtil.adaptException(e);
+        }
+    }
+
+    @Override
+    public QueueConnection createQueueConnection(String userName, String password) throws JMSException {
+        try {
+            return new JakartaQueueConnection(this.javaxQueueConnectionFactory.createQueueConnection(userName, password));
+        } catch (javax.jms.JMSException e) {
+            throw JMSExceptionUtil.adaptException(e);
+        }
+    }
+
+    @Override
+    public TopicConnection createTopicConnection() throws JMSException {
+        try {
+            return new JakartaTopicConnection(this.javaxTopicConnectionFactory.createTopicConnection());
+        } catch (javax.jms.JMSException e) {
+            throw JMSExceptionUtil.adaptException(e);
+        }
+    }
+
+    @Override
+    public TopicConnection createTopicConnection(String userName, String password) throws JMSException {
+        try {
+            return new JakartaTopicConnection(this.javaxTopicConnectionFactory.createTopicConnection(userName, password));
+        } catch (javax.jms.JMSException e) {
+            throw JMSExceptionUtil.adaptException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/github/marschall/jakartajmsadapter/Wrapper.java
+++ b/src/main/java/com/github/marschall/jakartajmsadapter/Wrapper.java
@@ -36,7 +36,9 @@ public interface Wrapper {
       // JMSReplyTo or JMSDestination can be null
       return null;
     }
-    if (destination instanceof javax.jms.Topic topic) {
+    if (destination instanceof javax.jms.Queue && destination instanceof javax.jms.Topic) {
+      return new JakartaQueueTopic(destination);
+    } else if (destination instanceof javax.jms.Topic topic) {
       return fromJavaxTopic(topic);
     } else if (destination instanceof javax.jms.Queue queue) {
       return fromJavaxQueue(queue);


### PR DESCRIPTION
We have an application being migrated to Spring Boot 3 that connects to queues and topics from a Weblogic 12. Since Weblogic's ConnectionFactory implements both QueueConnectionFactory and TopicConnectionFactory, and Weblogic's DestinationImpl implements both Queue and Topic, I needed another pair of wrappers for that use case.
